### PR TITLE
Leave node unaltered when translation is missing

### DIFF
--- a/src/traduki/core.clj
+++ b/src/traduki/core.clj
@@ -7,7 +7,11 @@
         translation-type (keyword translation-type-string)
         translation-key (keyword translation-key-string)
         translation (translator translation-key)]
+    
     (cond
+      (nil? translation)
+      node
+      
       (= :content translation-type)
       (assoc node :content (list translation))
 

--- a/test/traduki/test/core.clj
+++ b/test/traduki/test/core.clj
@@ -74,6 +74,17 @@
             first
             (enlv/text)) => "TRANSLATED_CONTENT"))
 
+(tabular
+ (fact "when translation is not provided, node is left unaltered"
+       (against-background
+        (mock-translator anything) => nil)
+       (let [enlive-element (html-string->enlive ?html-fragment)]
+         (translate mock-translator enlive-element) => enlive-element))
+ ?html-fragment
+ "<p data-l8n=\"content:translation-key\">old-content</p>"
+ "<p data-l8n=\"attr/title:translation-key\">old-content</p>"
+ "<p data-l8n=\"html:translation-key\">old-content</p>")
+
 (def translator
   (fn [translation-key]
     (case translation-key


### PR DESCRIPTION
Hi Rob,

Just a quick PR to not remove existing content when a translation is missing.

D
